### PR TITLE
adding sonar properties to point to demo project

### DIFF
--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -18,14 +18,9 @@ jobs:
       uses: sonarsource/sonarcloud-github-action@master
       with:
         projectBaseDir: src
-#         args: >
-#           -Dsonar.organization=my-organization
-#           -Dsonar.projectKey=my-projectkey
-#           -Dsonar.python.coverage.reportPaths=coverage.xml
-#           -Dsonar.sources=lib/
-#           -Dsonar.test.exclusions=tests/**
-#           -Dsonar.tests=tests/
-#           -Dsonar.verbose=true      
+        args: >
+           -Dsonar.organization=fooooooo
+           -Dsonar.projectKey=barrrrrrrrr
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -4,4 +4,4 @@ sonar.projectKey=barrrrrrrrr
 
 # relative paths to source directories. More details and properties are described
 # in https://sonarcloud.io/documentation/project-administration/narrowing-the-focus/ 
-sonar.sources=.
+sonar.sources=./src


### PR DESCRIPTION
Fixing error:

```
ERROR: You must define the following mandatory properties for 'Unknown': sonar.projectKey, sonar.organization
```

ensuring properties file and inline properties all point to right project and src dir.